### PR TITLE
Generation option: disable costly action yield requirement

### DIFF
--- a/modinfo.txt
+++ b/modinfo.txt
@@ -1,3 +1,3 @@
 name = Incognita Socket: Online Multiplayer
 author = Cyberboy2000
-version = 2.1
+version = 2.2

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -26,6 +26,7 @@ local function init( modApi )
 			multiMod.GAME_MODES.BACKSTAB,
 		}
 	})
+	modApi:addGenerationOption("requireCostlyToYield",STRINGS.MULTI_MOD.REQUIRE_COSTLY_TO_YIELD.NAME,STRINGS.MULTI_MOD.REQUIRE_COSTLY_TO_YIELD.TIP,{noUpdate=true})
 	modApi:addGenerationOption("votingMode",STRINGS.MULTI_MOD.MISSION_VOTING.NAME,STRINGS.MULTI_MOD.MISSION_VOTING.TIP,
 	{
 		noUpdate=true,
@@ -39,7 +40,7 @@ local function init( modApi )
 	})
 	
 	multiMod.DEFAULT_PORT = 27017
-	multiMod.MULTI_MOD_VERSION = 2.1
+	multiMod.MULTI_MOD_VERSION = 2.2
 	--multiMod.COMPABILITY_VERSION = 2 -- Moved to load!!!
 	multiMod.WERP_ADRESS = "werp.site"
 	multiMod.WERP_PORT = 31337
@@ -90,8 +91,13 @@ local function load( modApi, options, params )
 	if options["votingMode"] then
 		multiMod.votingMode = options["votingMode"].value
 	end
+	if options["requireCostlyToYield"] then
+		multiMod.requireCostlyToYield = options["requireCostlyToYield"].enabled
+	end
 	
-	if multiMod.gameMode ~= multiMod.GAME_MODES.FREEFORALL or (params and params.timeAttack and params.timeAttack > 0) then
+	if not multiMod.requireCostlyToYield and multiMod.gameMode == multiMod.GAME_MODES.BACKSTAB then
+		multiMod.COMPABILITY_VERSION = 2.2
+	elseif multiMod.gameMode ~= multiMod.GAME_MODES.FREEFORALL or (params and params.timeAttack and params.timeAttack > 0) then
 		multiMod.COMPABILITY_VERSION = 2.1
 	else
 		multiMod.COMPABILITY_VERSION = 2

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -612,6 +612,10 @@ function stateMultiplayer:shouldYield()
 	
 	for i = #self.onlineHistory, 1, -1 do
 		local pastAction = self.onlineHistory[i]
+		if not self.requireCostlyToYield and pastAction.name ~= "yieldTurnAction" then
+			log:write("costly not required, should yield")
+			break
+		end
 		if pastAction.name == "endTurnAction" or pastAction.name == "moveAction" or pastAction.costly then
 			break
 		end

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -613,7 +613,6 @@ function stateMultiplayer:shouldYield()
 	for i = #self.onlineHistory, 1, -1 do
 		local pastAction = self.onlineHistory[i]
 		if not self.requireCostlyToYield and pastAction.name ~= "yieldTurnAction" then
-			log:write("costly not required, should yield")
 			break
 		end
 		if pastAction.name == "endTurnAction" or pastAction.name == "moveAction" or pastAction.costly then

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -21,6 +21,11 @@ local MULTI_MOD = {
 			"HOST DECIDES",
 		}
 	},
+
+	REQUIRE_COSTLY_TO_YIELD = {
+		NAME = "REQUIRE COSTLY ACTIONS TO YIELD TURN",
+		TIP = "If enabled (default), yielding the turn in Backstab Protocols mode will only be available after taking costly actions, otherwise turn ends instead.\nIf disabled, taking any action will allow yielding the turn.",
+	},
 	
 	BUTTON_HOST = "HOST",
 	BUTTON_JOIN = "JOIN",


### PR DESCRIPTION
A new generation option controls whether taking costly actions is required to yield turn in Backstab mode. If disabled, ending turns requires consecutive yields from all players.

This is intended for a more relaxed cooperative experience where stalling might not be as undesirable.