### PR TITLE
Add proper tooltips for end turn button

### DIFF
--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -3,6 +3,7 @@ local version = include( "modules/version" )
 local mui = include("mui/mui")
 local mui_defs = include("mui/mui_defs")
 local mui_util = include("mui/mui_util")
+local mui_tooltip = include("mui/mui_tooltip")
 local cdefs = include( "client_defs" )
 local modalDialog = include( "states/state-modal-dialog" )
 local cheatmenu = include( "fe/cheatmenu" )
@@ -822,13 +823,25 @@ function stateMultiplayer:updateEndTurnButton()
 		if self.isFocusedPlayer then
 			if self:shouldYield() then
 				btn:setText(STRINGS.MULTI_MOD.YIELD)
+				local tooltip = mui_tooltip(STRINGS.MULTI_MOD.YIELD_TOOLTIP_HEADER, STRINGS.MULTI_MOD.YIELD_TOOLTIP, STRINGS.SCREENS.STR_194569200)
+				btn:setTooltip(tooltip)
 			else
 				btn:setText(STRINGS.SCREENS.STR_3530899842) -- End Turn
+				local tooltip = mui_tooltip(STRINGS.SCREENS.STR_1207454442, STRINGS.SCREENS.STR_610854735, STRINGS.SCREENS.STR_194569200)	-- default tooltip
+				btn:setTooltip(tooltip)
 			end
 		elseif self.game.simCore and self.game.simCore.currentClientName then
 			btn:setText(string.format(STRINGS.MULTI_MOD.YIELDED_TO, self.game.simCore.currentClientName))
+			local tooltip = mui_tooltip(
+				STRINGS.MULTI_MOD.YIELDED_TO_TOOLTIP_HEADER,
+				string.format(STRINGS.MULTI_MOD.YIELDED_TO_TOOLTIP, self.game.simCore.currentClientName),
+				nil		-- do not show hotkey, as it does nothing
+			)
+			btn:setTooltip(tooltip)
 		else
 			btn:setText(STRINGS.SCREENS.STR_3530899842) -- End Turn
+			local tooltip = mui_tooltip(STRINGS.SCREENS.STR_1207454442, STRINGS.SCREENS.STR_610854735, STRINGS.SCREENS.STR_194569200)	-- default tooltip
+			btn:setTooltip(tooltip)
 		end
 	end
 end

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -57,6 +57,11 @@ local MULTI_MOD = {
 	BACKSTAB_YIELD_SWIPE = "%s ACTIVITY",
 	YIELD = "YIELD TURN",
 	YIELDED_TO = "%s TURN",
+
+	YIELD_TOOLTIP_HEADER = "YIELD TURN",
+	YIELD_TOOLTIP = "Pass the turn to another player.",
+	YIELDED_TO_TOOLTIP_HEADER = "TURN YIELDED",
+	YIELDED_TO_TOOLTIP = "%s is currently taking their turn.",
 	
 	PANEL = {
 		TITLE = "Game Title",


### PR DESCRIPTION
End Turn button's tooltip will now change to match its current status.