### PR TITLE
Improve turn visibility: sound and color

### DIFF
--- a/scripts/simactions2.lua
+++ b/scripts/simactions2.lua
@@ -1,6 +1,6 @@
 local simactions = include( "sim/simactions" )
 
-simactions.yieldTurnAction = function( sim, clientName, previousFocusedPlayerIndex, focusedPlayerIndex, isFocusedPlayer )
+simactions.yieldTurnAction = function( sim, clientName, previousFocusedPlayerIndex, focusedPlayerIndex )
 	sim.currentClientName = clientName
-	sim:dispatchEvent( "BACKSTAB_TURN_YIELD", {name = clientName, isFocusedPlayer = isFocusedPlayer} )
+	sim:dispatchEvent( "BACKSTAB_TURN_YIELD", {name = clientName} )
 end

--- a/scripts/simactions2.lua
+++ b/scripts/simactions2.lua
@@ -1,6 +1,6 @@
 local simactions = include( "sim/simactions" )
 
-simactions.yieldTurnAction = function( sim, clientName, previousFocusedPlayerIndex, focusedPlayerIndex )
+simactions.yieldTurnAction = function( sim, clientName, previousFocusedPlayerIndex, focusedPlayerIndex, isFocusedPlayer )
 	sim.currentClientName = clientName
-	sim:dispatchEvent( "BACKSTAB_TURN_YIELD", {name = clientName} )
+	sim:dispatchEvent( "BACKSTAB_TURN_YIELD", {name = clientName, isFocusedPlayer = isFocusedPlayer} )
 end

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -327,6 +327,7 @@ function stateMultiplayer:receiveData(client,data,line)
 		elseif self:isClient() then
 			if data.focus then
 				self.isFocusedPlayer = true
+				MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
 				self:updateEndTurnButton()
 			elseif data.plCoun then
 				self.playerCount = data.plCoun
@@ -578,6 +579,7 @@ function stateMultiplayer:yield(playerIndex)
 		else
 			self.focusedPlayerIndex = 0
 			self.isFocusedPlayer = true
+			MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
 			clientName = self.userName
 		end
 	
@@ -656,6 +658,7 @@ function stateMultiplayer:focusFirstPlayer()
 	else
 		self.focusedPlayerIndex = 0
 		self.isFocusedPlayer = true
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
 		clientName = self.userName
 	end
 	

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -581,7 +581,7 @@ function stateMultiplayer:yield(playerIndex)
 			clientName = self.userName
 		end
 	
-		local action = { name = "yieldTurnAction", clientName, previousFocusedPlayerIndex, self.focusedPlayerIndex }
+		local action = { name = "yieldTurnAction", clientName, previousFocusedPlayerIndex, self.focusedPlayerIndex, self.isFocusedPlayer }
 		
 		if not self:shouldYield() then
 			action.costly = true
@@ -659,7 +659,7 @@ function stateMultiplayer:focusFirstPlayer()
 		clientName = self.userName
 	end
 	
-	local action = { name = "yieldTurnAction", costly = true, clientName, nil, self.focusedPlayerIndex }
+	local action = { name = "yieldTurnAction", costly = true, clientName, nil, self.focusedPlayerIndex, self.isFocusedPlayer }
 	
 	self:sendAction( action )
 	if self:getCurrentGame() then

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -327,7 +327,6 @@ function stateMultiplayer:receiveData(client,data,line)
 		elseif self:isClient() then
 			if data.focus then
 				self.isFocusedPlayer = true
-				MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
 				self:updateEndTurnButton()
 			elseif data.plCoun then
 				self.playerCount = data.plCoun
@@ -579,7 +578,6 @@ function stateMultiplayer:yield(playerIndex)
 		else
 			self.focusedPlayerIndex = 0
 			self.isFocusedPlayer = true
-			MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
 			clientName = self.userName
 		end
 	
@@ -658,7 +656,6 @@ function stateMultiplayer:focusFirstPlayer()
 	else
 		self.focusedPlayerIndex = 0
 		self.isFocusedPlayer = true
-		MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
 		clientName = self.userName
 	end
 	

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -581,7 +581,7 @@ function stateMultiplayer:yield(playerIndex)
 			clientName = self.userName
 		end
 	
-		local action = { name = "yieldTurnAction", clientName, previousFocusedPlayerIndex, self.focusedPlayerIndex, self.isFocusedPlayer }
+		local action = { name = "yieldTurnAction", clientName, previousFocusedPlayerIndex, self.focusedPlayerIndex }
 		
 		if not self:shouldYield() then
 			action.costly = true
@@ -659,7 +659,7 @@ function stateMultiplayer:focusFirstPlayer()
 		clientName = self.userName
 	end
 	
-	local action = { name = "yieldTurnAction", costly = true, clientName, nil, self.focusedPlayerIndex, self.isFocusedPlayer }
+	local action = { name = "yieldTurnAction", costly = true, clientName, nil, self.focusedPlayerIndex }
 	
 	self:sendAction( action )
 	if self:getCurrentGame() then

--- a/scripts/viz/yieldTurn.lua
+++ b/scripts/viz/yieldTurn.lua
@@ -2,25 +2,19 @@ local util = include( "client_util" )
 local cdefs = include( "client_defs" )
 local rig_util = include( "gameplay/rig_util" )
 
-local function stopTitleSwipe(hud, isFocusedPlayer)
-	if not isFocusedPlayer then
-		MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_out" )
-	end
+local function stopTitleSwipe(hud)
+	MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_out" )
     rig_util.waitForAnim(  hud._screen.binder.swipe.binder.anim:getProp(), "pst" )
     hud._screen.binder.swipe:setVisible(false)
 end
 
-local function startTitleSwipe( hud, swipeText,color,sound,showCorpTurn,turn,isFocusedPlayer)
+local function startTitleSwipe( hud, swipeText,color,sound,showCorpTurn,turn)
 	
 	MOAIFmodDesigner.playSound( sound )
 	hud._screen.binder.swipe:setVisible(true)
 	hud._screen.binder.swipe.binder.anim:setColor(color.r, color.g, color.b, color.a )	
 	hud._screen.binder.swipe.binder.anim:setAnim("pre")
-	if isFocusedPlayer then
-		MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
-	else
-		MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_in" )
-	end
+	MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_in" )
 
 	hud._screen.binder.swipe.binder.txt:spoolText(string.format(swipeText))	
 	hud._screen.binder.swipe.binder.txt:setColor(color.r, color.g, color.b, color.a )	
@@ -49,16 +43,9 @@ local function wait( event, evType, evData, boardRig, hud, vizThread )
 	
 	local turn = math.ceil( (boardRig:getSim():getTurnCount() + 1) / 2)
 
-	local color
-
-	if evData.isFocusedPlayer then
-		color = {r=244/255, g=255/255, b=120/255, a=1}
-	else
-		color = {r=140/255, g=255/255, b=255/255, a=1}
-	end
-	startTitleSwipe( hud, txt, color, cdefs.SOUND_HUD_GAME_ACTIVITY_AGENT, false, turn, evData.isFocusedPlayer )
+	startTitleSwipe( hud, txt, {r=140/255,g=255/255 ,b=255/255,a=1}, cdefs.SOUND_HUD_GAME_ACTIVITY_AGENT, false, turn)
 	rig_util.wait(30)		
-	stopTitleSwipe( hud, evData.isFocusedPlayer )
+	stopTitleSwipe( hud )
 end
 
 return wait

--- a/scripts/viz/yieldTurn.lua
+++ b/scripts/viz/yieldTurn.lua
@@ -3,7 +3,9 @@ local cdefs = include( "client_defs" )
 local rig_util = include( "gameplay/rig_util" )
 
 local function stopTitleSwipe(hud)
-	MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_out" )
+	if not multiMod.isFocusedPlayer then
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_out" )
+	end
     rig_util.waitForAnim(  hud._screen.binder.swipe.binder.anim:getProp(), "pst" )
     hud._screen.binder.swipe:setVisible(false)
 end
@@ -14,7 +16,11 @@ local function startTitleSwipe( hud, swipeText,color,sound,showCorpTurn,turn)
 	hud._screen.binder.swipe:setVisible(true)
 	hud._screen.binder.swipe.binder.anim:setColor(color.r, color.g, color.b, color.a )	
 	hud._screen.binder.swipe.binder.anim:setAnim("pre")
-	MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_in" )
+	if multiMod.isFocusedPlayer then
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
+	else
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_in" )
+	end
 
 	hud._screen.binder.swipe.binder.txt:spoolText(string.format(swipeText))	
 	hud._screen.binder.swipe.binder.txt:setColor(color.r, color.g, color.b, color.a )	
@@ -43,7 +49,14 @@ local function wait( event, evType, evData, boardRig, hud, vizThread )
 	
 	local turn = math.ceil( (boardRig:getSim():getTurnCount() + 1) / 2)
 
-	startTitleSwipe( hud, txt, {r=140/255,g=255/255 ,b=255/255,a=1}, cdefs.SOUND_HUD_GAME_ACTIVITY_AGENT, false, turn)
+	local color
+	if multiMod.isFocusedPlayer then
+		color = {r=244/255, g=255/255, b=120/255, a=1}
+	else
+		color = {r=140/255, g=255/255, b=255/255, a=1}
+	end
+	startTitleSwipe( hud, txt, color, cdefs.SOUND_HUD_GAME_ACTIVITY_AGENT, false, turn )
+
 	rig_util.wait(30)		
 	stopTitleSwipe( hud )
 end

--- a/scripts/viz/yieldTurn.lua
+++ b/scripts/viz/yieldTurn.lua
@@ -2,19 +2,25 @@ local util = include( "client_util" )
 local cdefs = include( "client_defs" )
 local rig_util = include( "gameplay/rig_util" )
 
-local function stopTitleSwipe(hud)
-	MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_out" )
+local function stopTitleSwipe(hud, isFocusedPlayer)
+	if not isFocusedPlayer then
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_out" )
+	end
     rig_util.waitForAnim(  hud._screen.binder.swipe.binder.anim:getProp(), "pst" )
     hud._screen.binder.swipe:setVisible(false)
 end
 
-local function startTitleSwipe( hud, swipeText,color,sound,showCorpTurn,turn)
+local function startTitleSwipe( hud, swipeText,color,sound,showCorpTurn,turn,isFocusedPlayer)
 	
 	MOAIFmodDesigner.playSound( sound )
 	hud._screen.binder.swipe:setVisible(true)
 	hud._screen.binder.swipe.binder.anim:setColor(color.r, color.g, color.b, color.a )	
 	hud._screen.binder.swipe.binder.anim:setAnim("pre")
-	MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_in" )
+	if isFocusedPlayer then
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
+	else
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/gameplay/turnswitch_in" )
+	end
 
 	hud._screen.binder.swipe.binder.txt:spoolText(string.format(swipeText))	
 	hud._screen.binder.swipe.binder.txt:setColor(color.r, color.g, color.b, color.a )	
@@ -43,9 +49,16 @@ local function wait( event, evType, evData, boardRig, hud, vizThread )
 	
 	local turn = math.ceil( (boardRig:getSim():getTurnCount() + 1) / 2)
 
-	startTitleSwipe( hud, txt, {r=140/255,g=255/255 ,b=255/255,a=1}, cdefs.SOUND_HUD_GAME_ACTIVITY_AGENT, false, turn)
+	local color
+
+	if evData.isFocusedPlayer then
+		color = {r=244/255, g=255/255, b=120/255, a=1}
+	else
+		color = {r=140/255, g=255/255, b=255/255, a=1}
+	end
+	startTitleSwipe( hud, txt, color, cdefs.SOUND_HUD_GAME_ACTIVITY_AGENT, false, turn, evData.isFocusedPlayer )
 	rig_util.wait(30)		
-	stopTitleSwipe( hud )
+	stopTitleSwipe( hud, evData.isFocusedPlayer )
 end
 
 return wait


### PR DESCRIPTION
In a game with multiple players, it is easy to get distracted while waiting and not notice when your turn begins. This PR introduces the following changes into Backstab Protocols mode:

* A sound effect that plays at the start of your turn. I have picked Incognita's "Warning!" for now, as it is recognizable and relatively rarely used in the game. Alternative suggestions are welcome.
* Title swipe is colored yellow instead of blue if it is your turn.