### PR TITLE
Autoyielding

### DIFF
--- a/scripts/state-game.lua
+++ b/scripts/state-game.lua
@@ -34,12 +34,22 @@ function game:doAction( actionName, ... )
 	local canTakeAction = multiMod:canTakeAction( actionName, ... )
 	local canLocallyTakeAction = multiMod:canTakeLocalAction( actionName, ... )
 	
+	if multiMod.gameMode == multiMod.GAME_MODES.BACKSTAB and actionName == "endTurnAction" then
+		if multiMod:hasYielded() then
+			if multiMod.autoYield then
+				multiMod.autoYield = false
+			else
+				multiMod.autoYield = true
+			end
+			multiMod:updateEndTurnButton()
+			return
+		else
+			return multiMod:yield(0)
+		end
+	end
+
 	if multiMod:hasYielded() and actionName ~= "mapPinAction" then
 		return
-	end
-	
-	if multiMod.gameMode == multiMod.GAME_MODES.BACKSTAB and actionName == "endTurnAction" and not multiMod:hasYielded() then
-		return multiMod:yield(0)
 	end
 	
 	if multiMod:getUplink() and self.syncedChessTimer then
@@ -84,6 +94,7 @@ function game:doRemoteAction(action)
 		local actionName = action.name
 		
 		if actionName == "endTurnAction" then
+			multiMod.autoYield = false
 			if self.hud then
 				self.hud:abortChoiceDialog()
 				self.hud:hideItemsPanel()
@@ -213,6 +224,7 @@ function game:onLoad( ... )
 	oldOnLoad( self, ... )
 	
 	if multiMod:getUplink() then
+		multiMod.autoYield = false
 		multiMod:startGame(self)
 		
 		local oldUpdateTimeAttack = self.updateTimeAttack

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -327,6 +327,9 @@ function stateMultiplayer:receiveData(client,data,line)
 		elseif self:isClient() then
 			if data.focus then
 				self.isFocusedPlayer = true
+				if self.autoYield then
+					self:yield(self.focusedPlayerIndex)
+				end
 				self:updateEndTurnButton()
 			elseif data.plCoun then
 				self.playerCount = data.plCoun
@@ -599,6 +602,10 @@ function stateMultiplayer:yield(playerIndex)
 		
 		if nextClient then
 			self.uplink:sendTo({focus = true},nextClient)
+		else
+			if self.autoYield then
+				self:yield(self.focusedPlayerIndex)
+			end
 		end
 	else
 		local action = { yield = true }
@@ -670,6 +677,10 @@ function stateMultiplayer:focusFirstPlayer()
 
 	if client then
 		self.uplink:sendTo({focus = true},client)
+	else
+		if self.autoYield then
+			self:yield(self.focusedPlayerIndex)
+		end
 	end
 end
 
@@ -824,17 +835,21 @@ end
 function stateMultiplayer:updateEndTurnButton()
 	if self.game and self.game.hud and self.gameMode == self.GAME_MODES.BACKSTAB then
 		local btn = self.game.hud._screen.binder.endTurnBtn
-		
+		local suffix = ""
+
+		if self.autoYield then
+			suffix = STRINGS.MULTI_MOD.AUTOYIELDING_SUFFIX
+		end
 		if self.isFocusedPlayer then
 			if self:shouldYield() then
-				btn:setText(STRINGS.MULTI_MOD.YIELD)
+				btn:setText(STRINGS.MULTI_MOD.YIELD .. suffix)
 			else
-				btn:setText(STRINGS.SCREENS.STR_3530899842) -- End Turn
+				btn:setText(STRINGS.SCREENS.STR_3530899842 .. suffix) -- End Turn
 			end
 		elseif self.game.simCore and self.game.simCore.currentClientName then
-			btn:setText(string.format(STRINGS.MULTI_MOD.YIELDED_TO, self.game.simCore.currentClientName))
+			btn:setText(string.format(STRINGS.MULTI_MOD.YIELDED_TO, self.game.simCore.currentClientName) .. suffix)
 		else
-			btn:setText(STRINGS.SCREENS.STR_3530899842) -- End Turn
+			btn:setText(STRINGS.SCREENS.STR_3530899842 .. suffix) -- End Turn
 		end
 	end
 end

--- a/scripts/state-multiplayer.lua
+++ b/scripts/state-multiplayer.lua
@@ -573,7 +573,6 @@ function stateMultiplayer:yield(playerIndex)
 		
 		if nextClient then
 			self.focusedPlayerIndex = nextClient.clientIndex
-			self.uplink:sendTo({focus = true},nextClient)
 			clientName = nextClient.userName
 		else
 			self.focusedPlayerIndex = 0
@@ -596,6 +595,10 @@ function stateMultiplayer:yield(playerIndex)
 		self:sendAction( action )
 		if self.game then
 			self.game:doRemoteAction(action)
+		end
+		
+		if nextClient then
+			self.uplink:sendTo({focus = true},nextClient)
 		end
 	else
 		local action = { yield = true }
@@ -651,7 +654,6 @@ function stateMultiplayer:focusFirstPlayer()
 	if client then
 		self.isFocusedPlayer = false
 		self.focusedPlayerIndex = self.uplink.clients[r].clientIndex
-		self.uplink:sendTo({focus = true},client)
 		clientName = client.userName
 	else
 		self.focusedPlayerIndex = 0
@@ -664,6 +666,10 @@ function stateMultiplayer:focusFirstPlayer()
 	self:sendAction( action )
 	if self:getCurrentGame() then
 		self:getCurrentGame():doRemoteAction(action)	
+	end
+
+	if client then
+		self.uplink:sendTo({focus = true},client)
 	end
 end
 

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -57,6 +57,7 @@ local MULTI_MOD = {
 	BACKSTAB_YIELD_SWIPE = "%s ACTIVITY",
 	YIELD = "YIELD TURN",
 	YIELDED_TO = "%s TURN",
+	AUTOYIELDING_SUFFIX = " <c:F0FF78>(A/Y)</c>",
 	
 	PANEL = {
 		TITLE = "Game Title",


### PR DESCRIPTION
When playing with multiple players, it may become tedious to press "Yield" multiple times when you're certain you will take no further actions even though other players continue to act.

This PR introduces autoyielding to Backstab Protocols mode: if you press the "End Turn" button while it's another player's turn, "(A/Y)" will be appended to its label, and you will automatically yield/end turn when it becomes your turn. Autoyielding becomes disabled when the turn ends or when you press the button again.