### PR TITLE
"Not your turn" warning

### DIFF
--- a/scripts/state-game.lua
+++ b/scripts/state-game.lua
@@ -35,6 +35,12 @@ function game:doAction( actionName, ... )
 	local canLocallyTakeAction = multiMod:canTakeLocalAction( actionName, ... )
 	
 	if multiMod:hasYielded() and actionName ~= "mapPinAction" then
+		MOAIFmodDesigner.playSound( "SpySociety/HUD/voice/level1/alarmvoice_warning" )
+		self.hud:showWarning(
+			STRINGS.MULTI_MOD.NOT_YOUR_TURN_TITLE,
+			{r=1,g=1,b=1,a=1},
+			string.format(STRINGS.MULTI_MOD.NOT_YOUR_TURN_SUBTEXT, self.simCore.currentClientName)
+		)
 		return
 	end
 	

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -57,6 +57,9 @@ local MULTI_MOD = {
 	BACKSTAB_YIELD_SWIPE = "%s ACTIVITY",
 	YIELD = "YIELD TURN",
 	YIELDED_TO = "%s TURN",
+
+	NOT_YOUR_TURN_TITLE = "Not your turn",
+	NOT_YOUR_TURN_SUBTEXT = "%s is currently taking actions.",
 	
 	PANEL = {
 		TITLE = "Game Title",


### PR DESCRIPTION
If you try to take an action and it's not your turn in Backstab Protocols mode, a warning is now shown.