### PR TITLE
Send EV_UI_INITIALIZED in Backstab as well

### DIFF
--- a/scripts/state-game.lua
+++ b/scripts/state-game.lua
@@ -183,9 +183,9 @@ function game:fromOnlineHistory(onlineHistory)
 		end
 
 		if multiMod.gameMode == multiMod.GAME_MODES.BACKSTAB and self.simHistoryIdx == 0 then
-        	local level = include( "sim/level" )
-            self:dispatchScriptEvent( level.EV_UI_INITIALIZED )
-        end
+			local level = include( "sim/level" )
+			self:dispatchScriptEvent( level.EV_UI_INITIALIZED )
+		end
 
 		self.boardRig = boardrig( self.layers, self.levelData, self )
 		self.hud = hud.createHud( self )

--- a/scripts/state-game.lua
+++ b/scripts/state-game.lua
@@ -31,6 +31,7 @@ local function event_error_handler( err )
 end
 
 function game:doAction( actionName, ... )
+	-- log:write("Received action: "..actionName)
 	local canTakeAction = multiMod:canTakeAction( actionName, ... )
 	local canLocallyTakeAction = multiMod:canTakeLocalAction( actionName, ... )
 	
@@ -180,6 +181,11 @@ function game:fromOnlineHistory(onlineHistory)
 		if focusAction then
 			table.insert( self.simHistory, focusAction )
 		end
+
+		if multiMod.gameMode == multiMod.GAME_MODES.BACKSTAB and self.simHistoryIdx == 0 then
+        	local level = include( "sim/level" )
+            self:dispatchScriptEvent( level.EV_UI_INITIALIZED )
+        end
 
 		self.boardRig = boardrig( self.layers, self.levelData, self )
 		self.hud = hud.createHud( self )


### PR DESCRIPTION
This PR fixes Gana's teleporting ability and also reenables other things that depend on this event (like Central's first mission dialogue and mission objectives popup).